### PR TITLE
Fix 错误拼写; 补充缺失的Header File

### DIFF
--- a/code/day10/Makefile
+++ b/code/day10/Makefile
@@ -4,10 +4,10 @@ server:
 	-pthread \
 	src/util.cpp src/Epoll.cpp src/InetAddress.cpp src/Socket.cpp src/Connection.cpp \
 	src/Channel.cpp src/EventLoop.cpp src/Server.cpp src/Acceptor.cpp src/Buffer.cpp \
-	src/ThreadPoll.cpp \
+	src/ThreadPool.cpp \
 	-o server
 clean:
 	rm server && rm client
 
 threadTest:
-	g++ -pthread src/ThreadPoll.cpp ThreadPollTest.cpp -o ThreadPollTest
+	g++ -pthread src/ThreadPool.cpp ThreadPoolTest.cpp -o ThreadPoolTest

--- a/code/day10/ThreadPoolTest.cpp
+++ b/code/day10/ThreadPoolTest.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <string>
-#include "src/ThreadPoll.h"
+#include "src/ThreadPool.h"
 
 void print(int a, double b, const char *c, std::string d){
     std::cout << a << b << c << d << std::endl;
@@ -12,7 +12,7 @@ void test(){
 
 int main(int argc, char const *argv[])
 {
-    ThreadPoll *poll = new ThreadPoll();
+    ThreadPool *poll = new ThreadPool();
     std::function<void()> func = std::bind(print, 1, 3.14, "hello", std::string("world"));
     poll->add(func);
     func = test;

--- a/code/day10/src/Acceptor.h
+++ b/code/day10/src/Acceptor.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <functional>
-
+#include <cstdio>
 class EventLoop;
 class Socket;
 class Channel;

--- a/code/day10/src/EventLoop.cpp
+++ b/code/day10/src/EventLoop.cpp
@@ -1,12 +1,12 @@
 #include "EventLoop.h"
 #include "Epoll.h"
 #include "Channel.h"
-#include "ThreadPoll.h"
+#include "ThreadPool.h"
 #include <vector>
 
-EventLoop::EventLoop() : ep(nullptr), threadPoll(nullptr), quit(false){
+EventLoop::EventLoop() : ep(nullptr), threadPool(nullptr), quit(false){
     ep = new Epoll();
-    threadPoll = new ThreadPoll();
+    threadPool = new ThreadPool();
 }
 
 EventLoop::~EventLoop(){
@@ -29,5 +29,5 @@ void EventLoop::updateChannel(Channel *ch){
 }
 
 void EventLoop::addThread(std::function<void()> func){
-    threadPoll->add(func);
+    threadPool->add(func);
 }

--- a/code/day10/src/EventLoop.h
+++ b/code/day10/src/EventLoop.h
@@ -3,12 +3,12 @@
 
 class Epoll;
 class Channel;
-class ThreadPoll;
+class ThreadPool;
 class EventLoop
 {
 private:
     Epoll *ep;
-    ThreadPoll *threadPoll;
+    ThreadPool *threadPool;
     bool quit;
 public:
     EventLoop();

--- a/code/day10/src/ThreadPool.cpp
+++ b/code/day10/src/ThreadPool.cpp
@@ -1,6 +1,6 @@
-#include "ThreadPoll.h"
+#include "ThreadPool.h"
 
-ThreadPoll::ThreadPoll(int size) : stop(false){
+ThreadPool::ThreadPool(int size) : stop(false){
     for(int i = 0; i < size; ++i){
         threads.emplace_back(std::thread([this](){
             while(true){
@@ -20,7 +20,7 @@ ThreadPoll::ThreadPoll(int size) : stop(false){
     }
 }
 
-ThreadPoll::~ThreadPoll(){
+ThreadPool::~ThreadPool(){
     {
         std::unique_lock<std::mutex> lock(tasks_mtx);
         stop = true;
@@ -32,7 +32,7 @@ ThreadPoll::~ThreadPoll(){
     }
 }
 
-void ThreadPoll::add(std::function<void()> func){
+void ThreadPool::add(std::function<void()> func){
     {
         std::unique_lock<std::mutex> lock(tasks_mtx);
         if(stop)

--- a/code/day10/src/ThreadPool.h
+++ b/code/day10/src/ThreadPool.h
@@ -6,7 +6,7 @@
 #include <mutex>
 #include <condition_variable>
 
-class ThreadPoll
+class ThreadPool
 {
 private:
     std::vector<std::thread> threads;
@@ -15,8 +15,8 @@ private:
     std::condition_variable cv;
     bool stop;
 public:
-    ThreadPoll(int size = 10);
-    ~ThreadPoll();
+    ThreadPool(int size = 10);
+    ~ThreadPool();
 
     void add(std::function<void()>);
 

--- a/day10-加入线程池到服务器.md
+++ b/day10-加入线程池到服务器.md
@@ -13,7 +13,7 @@
 
 线程池定义如下：
 ```cpp
-class ThreadPoll {
+class ThreadPool {
 private:
     std::vector<std::thread> threads;
     std::queue<std::function<void()>> tasks;
@@ -21,14 +21,14 @@ private:
     std::condition_variable cv;
     bool stop;
 public:
-    ThreadPoll(int size = 10);  // 默认size最好设置为std::thread::hardware_concurrency()
-    ~ThreadPoll();
+    ThreadPool(int size = 10);  // 默认size最好设置为std::thread::hardware_concurrency()
+    ~ThreadPool();
     void add(std::function<void()>);
 };
 ```
 当线程池被构造时：
 ```cpp
-ThreadPoll::ThreadPoll(int size) : stop(false){
+ThreadPool::ThreadPool(int size) : stop(false){
     for(int i = 0; i < size; ++i){  //  启动size个线程
         threads.emplace_back(std::thread([this](){  //定义每个线程的工作函数
             while(true){    
@@ -50,7 +50,7 @@ ThreadPoll::ThreadPoll(int size) : stop(false){
 ```
 当我们需要添加任务时，只需要将任务添加到任务队列：
 ```cpp
-void ThreadPoll::add(std::function<void()> func){
+void ThreadPool::add(std::function<void()> func){
     { //在这个{}作用域内对std::mutex加锁，出了作用域会自动解锁，不需要调用unlock()
         std::unique_lock<std::mutex> lock(tasks_mtx);
         if(stop)


### PR DESCRIPTION
在看Day10 线程池时发现的一些问题:

+ 拼写`ThreadPool`为错误的`ThreadPoll` (自从Day11后就已经拼写正确了)
+ 在`Acceptor`的头文件里没有引入支持`printf`的`<cstdio>` 造成不能正确完成编译.

  ```
  void Acceptor::acceptConnection(){
      InetAddress *clnt_addr = new InetAddress();      
      Socket *clnt_sock = new Socket(sock->accept(clnt_addr));      
      printf("new client fd %d! IP: %s Port: %d\n", clnt_sock->getFd(), inet_ntoa(clnt_addr->getAddr().sin_addr), ntohs(clnt_addr->getAddr().sin_port));
      clnt_sock->setnonblocking();
      newConnectionCallback(clnt_sock);
      delete clnt_addr;
  }
  ```

此PR中
1. 修改了所有的`ThreadPool`拼写问题
2. 添加了`<cstdio>`到`Acceptor`头文件
3. 更新了day10 README
4. 更新了day10 MakeFile
5. 验证了修改后, 在Ubuntu 20.04 Linux上测试可以编译并运行测试